### PR TITLE
Updates jai_core dependency to jai-core

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ crossScalaVersions := Seq("2.11.8", "2.12.1")
 resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
 
 libraryDependencies ++= Seq(
-  "javax.media" % "jai_core" % "1.1.3" from "http://download.osgeo.org/webdav/geotools/javax/media/jai_core/1.1.3/jai_core-1.1.3.jar",
+  "javax.media" % "jai-core" % "1.1.3" from "https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/javax/media/jai-core/1.1.3/jai-core-1.1.3.jar",
   "org.scalactic" %% "scalactic" % "3.0.1",
   "org.scalatest" %% "scalatest" % "3.0.1" % "test",
   "com.jhlabs" % "filters" % "2.0.235-1"


### PR DESCRIPTION
The dependency "javax.media" % "jai_core" % "1.1.3" keeps trying to resolve from maven no matter what I try. 

it tries to resolve from maven it resolve from here: https://mvnrepository.com/artifact/javax.media/jai_core/1.1.3
In the repo its missing http://central.maven.org/maven2/javax/media/jai_core/1.1.3/jai_core-1.1.3.jar
This ends up making my project fail.

Changing the "_" to "-" ex: "javax.media" % "jai-core" % "1.1.3"  makes it work when it pulls from maven. https://mvnrepository.com/artifact/javax.media/jai-core/1.1.3
which is not missing the jar.